### PR TITLE
add content type to POST request for commands

### DIFF
--- a/clients/command.go
+++ b/clients/command.go
@@ -29,6 +29,8 @@ func (client GameyeClient) command(
 	if err != nil {
 		return
 	}
+	
+	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Authorization", authorization)
 
 	var res *http.Response


### PR DESCRIPTION
the api returns a 404 if you do not add the correct content-type to a POST !?

the current SDK failes to start a match ...